### PR TITLE
Modernize workflow actions and retarget to main

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,19 +3,19 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -28,7 +28,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist

--- a/README.md
+++ b/README.md
@@ -85,4 +85,4 @@ The content lives inside [`scripts/generate_resume.py`](scripts/generate_resume.
 
 ## Deployment
 
-Every push to `master` builds the site and publishes `dist/` to the `gh-pages` branch via [`.github/workflows/gh-pages.yml`](.github/workflows/gh-pages.yml). Pull requests get a build check but do not deploy.
+Every push to `main` builds the site and publishes `dist/` to the `gh-pages` branch via [`.github/workflows/gh-pages.yml`](.github/workflows/gh-pages.yml). Pull requests get a build check but do not deploy.


### PR DESCRIPTION
## Summary

Follow-up to the default-branch rename (`master` → `main`, done via the GitHub API — open PRs and clones retargeted):

- **Action version audit**: `actions/checkout` v4 → **v7**, `actions/setup-node` v4 → **v6** (checked against latest releases); `peaceiris/actions-gh-pages@v4` is already current
- **Branch triggers + deploy gate** updated from `master` to `main` — until this merges, pushes to `main` build but skip the deploy step, so merging this restores deployments
- README deployment note updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)